### PR TITLE
Add a Spam Filter Framework and Discord Invite Spam Prevention

### DIFF
--- a/aegis.js
+++ b/aegis.js
@@ -354,6 +354,54 @@ client.on("message", message => {
     }  
 })
 
+//Spam Filter Handling
+client.on("message", message => {
+    var guild = message.guild;
+    var guildConfig = config[guild.id];
+    var regexpapttern = /(?:https?:\/\/)?(?:www\.)?discord(?:\.gg|(?:app)?\.com\/invite)\/(\S+)/
+    var regexp = new RegExp(regexpapttern);
+    if(guildConfig.filters.discordInvites == true){
+        if(!regexp.test(message.content)){
+            return
+        }
+        var captures = message.content.match(regexpapttern)
+        client.fetchInvite(captures[0]).then(invite =>{
+            console.log(invite)
+            if(invite.guild.id != guild.id){
+                if(message.content.indexOf("discord.gg") != -1 && message.content.indexOf(`${invite.code}`) == -1){
+                    var currentcaseid = makeid();
+                    EvidenceDB.create({
+                        userid: message.author.id,
+                        CaseID: currentcaseid,
+                        typeOf: "WARN",
+                        dateAdded: message.createdTimestamp,
+                        evidenceLinks: "Automated Response",
+                        reason: "Automated action taken due to spammed Discord Link."
+                    });
+                    message.reply("This server does not allow users to send Discord Links. You have been warned for this infraction.");
+                    var logchannel = message.guild.channels.cache.get(config[message.guild.id].logchannels.moderator);
+                    if(!logchannel){
+                        logchannel = message.guild.channels.cache.get(config[message.guild.id].logchannels.default);
+                        if(!logchannel){
+                            message.delete();
+                            return message.channel.send("You do not have a logchannel configured. Contact your server owner.");
+                        }
+                    }
+                    const embed = new Discord.MessageEmbed()
+                        .addField("User ID", message.author.id)
+                        .addField("Added by", "Automated Spam Filter")
+                        .addField("Reason", `Posting a foreign discord link in ${message.channel.name}`)
+                        .setTimestamp(new Date())
+                        .setFooter("AEGIS-WARN Command | Case ID: " + currentcaseid)
+                        .setColor("#00C597");
+                    logchannel.send(`Warning log for **${message.author.tag}** - Case ID **${currentcaseid}**`, {embed});
+                    message.delete();
+                }
+            } 
+        }).catch();
+    }
+})
+
 client.on("messageDelete", message => {
     var mcontent = message.content;
     if(mcontent.length > 1023){
@@ -476,6 +524,9 @@ client.on("guildCreate", guild =>{
                 "enabled": false,
                 "categorychannel": "",
                 "allowedRoles": []
+            },
+            "filters": {
+                "discordInvites": false
             }
         }
         
@@ -720,6 +771,16 @@ client.on("messageReactionRemove", (messageReaction, user) =>{
     }
 });
 //END EVENT messageReactionRemove
+
+function makeid() {
+    var text = "";
+    var possible = "ABCDEFGHIJKLMNOPQRSTUVWXY0123456789";
+  
+    for (var i = 0; i < 5; i++)
+      text += possible.charAt(Math.floor(Math.random() * possible.length));
+  
+    return text;
+}
 
 process.on("unhandledRejection", err => {
     console.error("Uncaught Promise Error: \n", err);


### PR DESCRIPTION
+Added a Spam Filter Framework that allows for easier adding of spam provention measures in the future.

+Added the first of these measures - a discord link spam preventer. Will delete all discord (valid) invites spammed by users not on the exempt list. This can be enabled and managed using the new -filters conver (see `a!help configure`)